### PR TITLE
Version bump to allow Rails 6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     pg_serializable (2.0.0)
-      activerecord (~> 5.2)
-      activesupport (~> 5.2)
+      activerecord (>= 5.2, < 7.0)
+      activesupport (>= 5.2, < 7.0)
       oj (~> 3.6)
       pg (>= 1.1)
 
@@ -39,7 +39,7 @@ GEM
     json (2.2.0)
     method_source (0.9.2)
     minitest (5.11.3)
-    oj (3.7.12)
+    oj (3.9.0)
     pg (1.1.4)
     pry (0.12.2)
       coderay (~> 1.1.0)
@@ -83,4 +83,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   1.16.5
+   1.17.3

--- a/pg_serializable.gemspec
+++ b/pg_serializable.gemspec
@@ -30,8 +30,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 
-  spec.add_runtime_dependency "activesupport", "~> 5.2"
-  spec.add_runtime_dependency "activerecord", "~> 5.2"
+  spec.add_runtime_dependency "activesupport", ">= 5.2", "< 7.0"
+  spec.add_runtime_dependency "activerecord", ">= 5.2", "< 7.0"
   spec.add_runtime_dependency "pg", ">= 1.1"
   spec.add_runtime_dependency "oj", "~> 3.6"
 end


### PR DESCRIPTION
We wanna use this in a Rails 6 repo, but this gem current depends on `~5.2` of `ActiveRecord` and `ActiveSupport`.

I think this approach allows any version of `ActiveRecord` and `ActiveSupport` between `5.2` and `6.x`.

I'm not certain that this does not break compatibility with Rails `5.2` app.